### PR TITLE
Fixed poison glitch!  Right on!

### DIFF
--- a/FFL2R.py
+++ b/FFL2R.py
@@ -15,7 +15,7 @@ from FFL2R_manager_economy import GoldManager
 from FFL2R_manager_economy import ItemManager
 from FFL2R_manager_world import WorldManager
 
-VERSION = 3.21
+VERSION = 3.22
 DEBUG = False
 
 def main(fromWeb:bool, romData:mmap.mmap|None, rom_path:str|None, seed:int|None, encounterRate:int|None, goldDrops:int|None, 
@@ -90,6 +90,7 @@ def main(fromWeb:bool, romData:mmap.mmap|None, rom_path:str|None, seed:int|None,
         case 5: dadMagi = 0x0d
         case 6: dadMagi = 0x00
 
+    FFL2R_asm.Fixes.fixPoison(romData)
     FFL2R_asm.Fixes.missingTrigger(romData)
     FFL2R_asm.Fixes.magiFix(romData)
     FFL2R_asm.Fixes.mutantStr(romData)

--- a/FFL2R_asm.py
+++ b/FFL2R_asm.py
@@ -8,6 +8,11 @@ class Fixes:
     def missingTrigger(rom:mmap):
         rom[0x1e292] = 0x09
 
+    #fixes the poison glitch by having _target_fell_message
+    #call cscript 0x07 instead of 0x24
+    def fixPoison(rom:mmap):
+        rom[0x3154a] = 0x07
+
     #elemental magi fix, mana magi affinity enable
     def magiFix(rom:mmap):
         adjustments = {

--- a/FFL2R_asm.py
+++ b/FFL2R_asm.py
@@ -11,7 +11,7 @@ class Fixes:
     #fixes the poison glitch by having _target_fell_message
     #call cscript 0x07 instead of 0x24
     def fixPoison(rom:mmap):
-        rom[0x3154a] = 0x07
+        rom[0x31547] = 0x07
 
     #elemental magi fix, mana magi affinity enable
     def magiFix(rom:mmap):

--- a/FFL2R_asm.py
+++ b/FFL2R_asm.py
@@ -8,10 +8,10 @@ class Fixes:
     def missingTrigger(rom:mmap):
         rom[0x1e292] = 0x09
 
-    #fixes the poison glitch by having _target_fell_message
-    #call cscript 0x07 instead of 0x24
+    # Fixes poison glitch by pointing the poison death message call to one specifically for when the attacker falls.
     def fixPoison(rom:mmap):
-        rom[0x31547] = 0x07
+        rom[0x30c19] = 0x7b
+        rom[0x30c1a] = 0x6c
 
     #elemental magi fix, mana magi affinity enable
     def magiFix(rom:mmap):

--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@
     - Mutant stat growth behaves as expected.
     - Dooring/Pegasus/Teleporting during the race will now force a dismount.
 
+## Version 3.2.2 (6/14/2026):
+- Fixed poison glitch.
+
 ## Version 3.2.0 (6/14/2026):
 - Added functionality to be able to choose MAGI at the start.
 

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@
     - Mutant stat growth behaves as expected.
     - Dooring/Pegasus/Teleporting during the race will now force a dismount.
 
-## Version 3.2.2 (6/14/2026):
+## Version 3.2.2 (7/25/2026):
 - Fixed poison glitch.
 
 ## Version 3.2.0 (6/14/2026):


### PR DESCRIPTION
With help from saga2edit I was able to decompile the battle.script file and recompile it into assembly code rather than saga2edit code.  With additional help from tehtmi's technical notes included with it I was able to pinpoint the function that needed to be patched, _target_fell_message:

```
_target_fell_message:
    .db $a0
    .addr battle_script_index
    .db $cc $24 $1f $02
    .addr _execute_script
```

The above sets some parameters which results in combat script 0x24 being executed.  Problem with this is that when there are 16 entities total when the battle ends (any combination of player's party + monsters) via the last monster dying from poison damage after the last move by a party member targeted nothing (by having no moves left or using a shield) then combat script 0x24 will have some bad variables loaded and when the "XXXXXX fell" message happens it will start loading other values into the text box, resulting in a lot of funky stuff happening.

With a lot of time and patience I was able to finally pinpoint where in the original ROM itself that this exists in massive thanks to the 4 parameters being set before the _execute_script happens. :tada: 

By changing 0x24 to 0x07 we now execute a combat script that instead simply decrements the monster count and moves on without saying "XXXXXX fell".  This fixes the poison glitch.